### PR TITLE
added firstname lastname and username attribution when a user signs up

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,6 +15,9 @@
     <%= f.input :password_confirmation,
                 required: true,
                 input_html: { autocomplete: "new-password" } %>
+    <%= f.input :first_name %>
+    <%= f.input :last_name %>
+    <%= f.input :user_name %>
     <%= f.input :photo, as: :file %>
   </div>
 


### PR DESCRIPTION
When a new user signs up, he or she needs to fill up first name, last name and user name. By doing this, when a new chat is created and a message is sent by the user, the username will be showed up automatically. 